### PR TITLE
Keep order array for #array_to_hash method

### DIFF
--- a/lib/pubid/core/identifier/base.rb
+++ b/lib/pubid/core/identifier/base.rb
@@ -94,7 +94,7 @@ module Pubid::Core
           params.inject({}) do |r, i|
             result = r
             i.each do |k, v|
-              result = result.merge(k => r.key?(k) ? [v, r[k]].flatten : v)
+              result = result.merge(k => r.key?(k) ? [r[k], v].flatten : v)
             end
             result
           end

--- a/spec/pubid_core/identifier/base_spec.rb
+++ b/spec/pubid_core/identifier/base_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Pubid::Core::Identifier::Base do
     context "when same key repeating" do
       let(:input) { [{ a: 1 }, { a: 2 }] }
 
-      it { is_expected.to eq({ a: [2, 1] }) }
+      it { is_expected.to eq({ a: [1, 2] }) }
     end
   end
 


### PR DESCRIPTION
Needed to preserve copublishers name order