### PR TITLE
Convert entities like Stage, TypedStage, Supplement to hash format, friendly for storage (like YAML)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,5 +16,16 @@ pubid_first == pubid_second
 
 pubid_first.exclude(:year) == pubid_second
 => true
+----
 
+=== Using #to_h to convert identifier to hash
+
+
+[source,ruby]
+----
+require "pubid-core"
+
+pubid = Identifier.parse("ISO 1:1999")
+pubid.to_h
+=> { publisher: "ISO", number: 1, year: 1999 }
 ----

--- a/lib/pubid/core/identifier/base.rb
+++ b/lib/pubid/core/identifier/base.rb
@@ -65,14 +65,15 @@ module Pubid::Core
       # @return [Hash] Identifier's parameters
       def to_h
         instance_variables.map do |var|
-          # XXX: temporary hack to prepare typed_stage for rendering
-          # probably need to convert typed_stage to class, now we store
-          # typed_stage as key to typed stage (Symbol)
-          if var.to_s == "@typed_stage" && @typed_stage
-            [:typed_stage, self.class::TYPED_STAGES[@typed_stage][:abbr]]
-          else
-            [var.to_s.gsub("@", "").to_sym, instance_variable_get(var)]
-          end
+          value = instance_variable_get(var)
+
+          [var.to_s.gsub("@", "").to_sym,
+           if value.is_a?(Array)
+             value.map { |v| v.respond_to?(:to_h) ? v.to_h : v }
+           else
+             value.respond_to?(:to_h) ? value.to_h : value
+           end
+          ]
         end.to_h
       end
 

--- a/lib/pubid/core/stage.rb
+++ b/lib/pubid/core/stage.rb
@@ -101,5 +101,9 @@ module Pubid::Core
     def to_s(opts = {})
       empty_abbr?(**opts) ? "" : abbr
     end
+
+    def to_h
+      abbr
+    end
   end
 end

--- a/lib/pubid/core/supplement.rb
+++ b/lib/pubid/core/supplement.rb
@@ -33,5 +33,10 @@ module Pubid::Core
           ":#{@number}:v1"
         end
     end
+
+    def to_h
+      { number: number,
+        year: year }
+    end
   end
 end

--- a/lib/pubid/core/typed_stage.rb
+++ b/lib/pubid/core/typed_stage.rb
@@ -5,7 +5,7 @@ module Pubid::Core
     # @param config [Configuration]
     # @param abbr [Symbol] typed stage symbol, e.g. :dtr
     # @param harmonized_code [String, Float, HarmonizedStageCode]
-    def initialize(config:, abbr: nil, harmonized_code: nil)
+    def initialize(config:, abbr:, harmonized_code: nil)
       @config = config
       @abbr = abbr
 
@@ -18,19 +18,17 @@ module Pubid::Core
         # @abbr ||= lookup_abbr(@harmonized_code.stages)
       end
 
-      if abbr
-        raise Errors::TypedStageInvalidError, "#{abbr} is not valid typed stage" unless config.typed_stages.key?(abbr)
+      raise Errors::TypedStageInvalidError, "#{abbr} is not valid typed stage" unless config.typed_stages.key?(abbr)
 
-        @harmonized_code ||= HarmonizedStageCode.new(abbr, config: config)
-      end
+      @harmonized_code ||= HarmonizedStageCode.new(abbr, config: config)
     end
 
     # Compares one stage with another
     # should return false if
     def ==(other)
-      return false unless other
+      return false unless other.is_a?(self.class)
 
-      return abbr == other if other.is_a?(Symbol)
+      # return abbr == other if other.is_a?(Symbol)
 
       other&.harmonized_code == harmonized_code
     end

--- a/lib/pubid/core/version.rb
+++ b/lib/pubid/core/version.rb
@@ -1,5 +1,5 @@
 module Pubid
   module Core
-    VERSION = "1.10.0".freeze
+    VERSION = "1.10.1".freeze
   end
 end

--- a/spec/pubid_core/identifier/base_spec.rb
+++ b/spec/pubid_core/identifier/base_spec.rb
@@ -275,8 +275,8 @@ module Pubid::Core
       context "stage is a typed stage" do
         let(:stage) { "DTR" }
 
-        it "returns stage and according typed stage abbreviation" do
-          expect(subject).to eq(DummyTestIdentifier.build_stage(harmonized_code: %w[40.00], typed_stage: :dtr))
+        it "returns typed stage and according abbreviation" do
+          expect(subject).to eq(DummyTestIdentifier.build_typed_stage(harmonized_code: %w[40.00], abbr: :dtr))
         end
       end
 
@@ -322,6 +322,18 @@ module Pubid::Core
 
       context "with typed_stage" do
         let(:params) { { type: "tr", number: 1, publisher: "ISO", stage: :dtr } }
+
+        it { expect(subject).to eq(params) }
+      end
+
+      context "with stage" do
+        let(:params) { { type: "tr", number: 1, publisher: "ISO", stage: "WD" } }
+
+        it { expect(subject).to eq(params) }
+      end
+
+      context "with amendments" do
+        let(:params) { { type: "tr", number: 1, publisher: "ISO", amendments: [{ number: 1, year: 2000 }, { number: 2, year: 2000 }] } }
 
         it { expect(subject).to eq(params) }
       end


### PR DESCRIPTION
closes #22 