### PR TITLE
Compare identifier using #new_edition_of?

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,12 +36,11 @@ pubid.to_h
 require "pubid-core"
 
 pubid_first = Identifier.parse("ISO 1:1999")
-pubid_second = Identifier.parse("ISO 1")
+pubid_second = Identifier.parse("ISO 1:2000")
 
 pubid_first.new_edition_of?(pubid_second)
 => false
+pubid_second.new_edition_of?(pubid_first)
+=> true
 
-pubid_second = Identifier.parse("ISO 1:1998")
-pubid_first.new_edition_of?(pubid_second)
-=> false
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,6 @@ pubid_first.exclude(:year) == pubid_second
 
 === Using #to_h to convert identifier to hash
 
-
 [source,ruby]
 ----
 require "pubid-core"
@@ -28,4 +27,21 @@ require "pubid-core"
 pubid = Identifier.parse("ISO 1:1999")
 pubid.to_h
 => { publisher: "ISO", number: 1, year: 1999 }
+----
+
+=== Using #new_edition_of? to compare identifiers
+
+[source,ruby]
+----
+require "pubid-core"
+
+pubid_first = Identifier.parse("ISO 1:1999")
+pubid_second = Identifier.parse("ISO 1")
+
+pubid_first.new_edition_of?(pubid_second)
+=> false
+
+pubid_second = Identifier.parse("ISO 1:1998")
+pubid_first.new_edition_of?(pubid_second)
+=> false
 ----

--- a/lib/pubid/core/edition.rb
+++ b/lib/pubid/core/edition.rb
@@ -1,0 +1,26 @@
+module Pubid::Core
+  class Edition
+    include Comparable
+    attr_accessor :year, :number, :config
+
+    def initialize(config:, year: nil, number: nil)
+      @config = config
+      @year = year
+      @number = number
+    end
+
+    def <=>(other)
+      if other.year && year
+        return number <=> other.number if year == other.year
+
+        year <=> other.year
+      else
+        number <=> other.number
+      end
+    end
+
+    # def ==(other)
+    #   other.year == year && number == other.number
+    # end
+  end
+end

--- a/lib/pubid/core/errors.rb
+++ b/lib/pubid/core/errors.rb
@@ -9,5 +9,6 @@ module Pubid::Core
     class WrongTypeError < StandardError; end
     class TypedStageInvalidError < StandardError; end
     class AnotherDocumentError < StandardError; end
+    class CannotCompareError < StandardError; end
   end
 end

--- a/lib/pubid/core/errors.rb
+++ b/lib/pubid/core/errors.rb
@@ -8,6 +8,6 @@ module Pubid::Core
     class TypeStageParseError < StandardError; end
     class WrongTypeError < StandardError; end
     class TypedStageInvalidError < StandardError; end
-
+    class AnotherDocumentError < StandardError; end
   end
 end

--- a/lib/pubid/core/identifier/base.rb
+++ b/lib/pubid/core/identifier/base.rb
@@ -171,13 +171,23 @@ module Pubid::Core
       # @param other [Pubid::Core::Identifier::Base] pubid identifier to compare with
       # @return [Boolean] true if another identifier is newer edition
       def new_edition_of?(other)
-        raise Errors::AnotherDocumentError, "cannot compare edition with #{other}" unless exclude(:year) == other.exclude(:year)
+        if exclude(:year, :edition) != other.exclude(:year, :edition)
+          raise Errors::AnotherDocumentError, "cannot compare edition with #{other}"
+        end
 
-        return false if year.nil?
+        return true if year.nil?
 
-        return true if other.year.nil?
+        return false if other.year.nil?
 
-        year < other.year
+        if year == other.year && (edition || other.edition)
+          return false if other.edition.nil?
+
+          return true if edition.nil?
+
+          return edition > other.edition
+        end
+
+        year > other.year
       end
 
       class << self

--- a/lib/pubid/core/identifier/base.rb
+++ b/lib/pubid/core/identifier/base.rb
@@ -175,9 +175,9 @@ module Pubid::Core
           raise Errors::AnotherDocumentError, "cannot compare edition with #{other}"
         end
 
-        return true if year.nil?
-
-        return false if other.year.nil?
+        if year.nil? || other.year.nil?
+          raise Errors::CannotCompareError, "cannot compare identifier without edition year"
+        end
 
         if year == other.year && (edition || other.edition)
           return false if other.edition.nil?

--- a/lib/pubid/core/identifier/base.rb
+++ b/lib/pubid/core/identifier/base.rb
@@ -167,6 +167,19 @@ module Pubid::Core
         # @typed_stage = self.class::TYPED_STAGES[@typed_stage][:abbr] if @typed_stage
       end
 
+      # Checks if another identifier is newer edition of the same document
+      # @param other [Pubid::Core::Identifier::Base] pubid identifier to compare with
+      # @return [Boolean] true if another identifier is newer edition
+      def new_edition_of?(other)
+        raise Errors::AnotherDocumentError, "cannot compare edition with #{other}" unless exclude(:year) == other.exclude(:year)
+
+        return false if year.nil?
+
+        return true if other.year.nil?
+
+        year < other.year
+      end
+
       class << self
         # Parses given identifier
         # @param code_or_params [String, Hash] code or hash from parser

--- a/spec/pubid_core/identifier/base_spec.rb
+++ b/spec/pubid_core/identifier/base_spec.rb
@@ -454,20 +454,20 @@ module Pubid::Core
       context "when other identifier is newer edition" do
         let(:other_year) { 2000 }
 
-        it { is_expected.to be_truthy }
+        it { is_expected.to be_falsey }
       end
 
       context "when other identifier is older edition" do
         let(:other_year) { 1998 }
 
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
       end
 
       context "when other identifier don't have year" do
         let(:other_year) { nil }
 
         # identifier without year means it's latest edition
-        it { is_expected.to be_truthy }
+        it { is_expected.to be_falsey }
       end
 
       context "when other identifier is newer edition but another document" do
@@ -480,7 +480,54 @@ module Pubid::Core
         let(:year) { nil }
 
         # document without year means already latest edition
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when provided edition number" do
+        let(:params) { { number: 1, publisher: "ISO", year: year, edition: edition } }
+        let(:other_params) { { number: 1, publisher: "ISO", year: other_year, edition: other_edition } }
+        let(:edition) { 2 }
+
+        context "when other edition number higher" do
+          let(:other_edition) { 3 }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context "when other edition number lower" do
+          let(:other_edition) { 1 }
+
+          it { is_expected.to be_truthy }
+        end
+
+        context "when other edition number the same" do
+          let(:other_edition) { 2 }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context "when other identifier don't have edition number" do
+          let(:other_edition) { nil }
+
+          # no edition number means latest edition
+          it { is_expected.to be_falsey }
+        end
+
+        context "when original identifier don't have edition number" do
+          let(:edition) { nil }
+          let(:other_edition) { 2 }
+
+          # no edition number means latest edition
+          it { is_expected.to be_truthy }
+        end
+
+        context "when original identifier don't have year but have edition number" do
+          let(:edition) { 2 }
+          let(:other_edition) { 2 }
+          let(:year) { nil }
+
+          it { is_expected.to be_truthy }
+        end
       end
 
       context "when comparing supplements' editions" do
@@ -491,13 +538,13 @@ module Pubid::Core
         context "when other supplement is older edition" do
           let(:other_year) { 1998 }
 
-          it { is_expected.to be_falsey }
+          it { is_expected.to be_truthy }
         end
 
         context "when other supplement is newer edition" do
           let(:other_year) { 2000 }
 
-          it { is_expected.to be_truthy }
+          it { is_expected.to be_falsey }
         end
       end
     end

--- a/spec/pubid_core/identifier/base_spec.rb
+++ b/spec/pubid_core/identifier/base_spec.rb
@@ -466,8 +466,7 @@ module Pubid::Core
       context "when other identifier don't have year" do
         let(:other_year) { nil }
 
-        # identifier without year means it's latest edition
-        it { is_expected.to be_falsey }
+        it { expect { subject }.to raise_error(Errors::CannotCompareError) }
       end
 
       context "when other identifier is newer edition but another document" do
@@ -479,8 +478,7 @@ module Pubid::Core
       context "when original document without year" do
         let(:year) { nil }
 
-        # document without year means already latest edition
-        it { is_expected.to be_truthy }
+        it { expect { subject }.to raise_error(Errors::CannotCompareError) }
       end
 
       context "when provided edition number" do
@@ -526,7 +524,7 @@ module Pubid::Core
           let(:other_edition) { 2 }
           let(:year) { nil }
 
-          it { is_expected.to be_truthy }
+          it { expect { subject }.to raise_error(Errors::CannotCompareError) }
         end
       end
 

--- a/spec/support/01_dummy_types.rb
+++ b/spec/support/01_dummy_types.rb
@@ -1,7 +1,23 @@
 require 'forwardable'
 
 module Pubid::Core
-  class DummyDefaultType < Identifier::Base
+  module DummyTestIdentifier
+    class << self
+      include Pubid::Core::Identifier
+    end
+  end
+
+  class BaseTestIdentifier < Identifier::Base
+    def self.get_identifier
+      DummyTestIdentifier
+    end
+
+    def to_s
+      "#{@publisher} #{@number}"
+    end
+  end
+
+  class DummyDefaultType < BaseTestIdentifier
     extend Forwardable
     def_delegators 'Pubid::Core::DummyDefaultType', :type
 
@@ -10,7 +26,7 @@ module Pubid::Core
     end
   end
 
-  class DummyTechnicalReportType < Identifier::Base
+  class DummyTechnicalReportType < BaseTestIdentifier
     extend Forwardable
     def_delegators 'Pubid::Core::DummyTechnicalReportType', :type
 
@@ -31,7 +47,7 @@ module Pubid::Core
     end
   end
 
-  class DummyInternationalStandardType < Identifier::Base
+  class DummyInternationalStandardType < BaseTestIdentifier
     extend Forwardable
     def_delegators 'Pubid::Core::DummyInternationalStandardType', :type
 
@@ -58,7 +74,7 @@ module Pubid::Core
     end
   end
 
-  class DummyAmendment < Identifier::Base
+  class DummyAmendment < BaseTestIdentifier
     extend Forwardable
     def_delegators 'Pubid::Core::DummyAmendment', :type
 
@@ -71,12 +87,6 @@ module Pubid::Core
 
     def self.type
       { key: :amd, title: "Amendment", short: "Amd" }
-    end
-  end
-
-  module DummyTestIdentifier
-    class << self
-      include Pubid::Core::Identifier
     end
   end
 end


### PR DESCRIPTION
closes #49

In this implementation I only consider year to compare editions, numbers are ignored.
Need clarification on edition numbers here https://github.com/metanorma/pubid-iso/issues/274
